### PR TITLE
disable spellcheck

### DIFF
--- a/index.html
+++ b/index.html
@@ -20,7 +20,7 @@
 		</a>
 	</header>
 	<div class="container">
-		<div id="icon" class="icon">
+		<div id="icon" class="icon" spellcheck="false">
 			<span contenteditable>Edit</span>
 			<span contenteditable>here</span>
 		</div>


### PR DESCRIPTION
snipping and copying to clipboard is easier for sharing and spellcheck intervenes in between,
so disable it and when user feels like final product is ready, they can download the generated PNG image